### PR TITLE
Restore "Changed project to always build latest dev version"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM php:7.4-apache
 # MAINTAINER Austin St. Aubin <austinsaintaubin@gmail.com>
 
 # Build Environment Variables
-ENV VERSION 3.5.2
-ENV URL https://github.com/phpservermon/phpservermon/archive/v${VERSION}.tar.gz
+# ENV VERSION 3.5.2
+# ENV URL https://github.com/phpservermon/phpservermon/archive/v${VERSION}.tar.gz
+ENV URL https://github.com/phpservermon/phpservermon/archive/refs/heads/develop.zip
 
 # Install Base
 RUN apt-get update
@@ -57,8 +58,11 @@ VOLUME /sessions
 RUN set -ex; \
   cd /tmp; \
   rm -rf ${APACHE_DOCUMENT_ROOT}/*; \
-  curl --output phpservermonitor.tar.gz --location $URL; \
-  tar -xvf phpservermonitor.tar.gz --strip-components=1 -C ${APACHE_DOCUMENT_ROOT}/; \
+  curl --output phpservermonitor.zip --location $URL; \
+  unzip -d "${APACHE_DOCUMENT_ROOT}" "phpservermonitor.zip"; \
+  set -- "${APACHE_DOCUMENT_ROOT}"/*; \
+  mv "${APACHE_DOCUMENT_ROOT}"/*/* "${APACHE_DOCUMENT_ROOT}"/*/.[!.]* "${APACHE_DOCUMENT_ROOT}"; \
+  rmdir "$@"; \
   cd ${APACHE_DOCUMENT_ROOT}
 #   chown -R ${APACHE_RUN_USER}:www-data /var/www
 #   find /var/www -type d -exec chmod 750 {} \; ; \
@@ -70,7 +74,8 @@ RUN touch ${APACHE_DOCUMENT_ROOT}/config.php; \
     chmod 0777 ${APACHE_DOCUMENT_ROOT}/config.php
 
 # Composer install dependencies
-RUN composer install --no-dev -o
+# RUN composer install --no-dev -o
+RUN php composer.phar install
 
 # Add Entrypoint & Start Commands
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 
-# PHPServerMonitor in Docker (Last version 3.5.2)
-
-### Last update : 2020/09/09 . Created repository with version 3.5.2
-#### Please open issues on [github](https://github.com/Quentinvarquet/docker-phpservermonitor/issues)
+# PHPServerMonitor in Docker (latest [development version](https://github.com/phpservermon/phpservermon/commits/develop))
 
 ### PHPServerMonitor
 
@@ -35,7 +32,7 @@ cd phpservermonitor/
 
 # Build Docker Image
 docker build --no-cache \
-  --tag "phpservermonitor:3.5.2" \
+  --tag "phpservermonitor:dev" \
   --tag "phpservermonitor:latest" \
   --file Dockerfile .
 ```


### PR DESCRIPTION
Restore cn-tools/docker-phpservermonitor#3

Because latest stable 3.5.2 is too old (3+ years) and doesn't work correctly with new php Docker images (devices shown green even when down), this commit enables using always latest dev version.